### PR TITLE
- removed noexcept in move assignment operator

### DIFF
--- a/xpas/include/xpas/phylo_kmer_db.h
+++ b/xpas/include/xpas/phylo_kmer_db.h
@@ -43,7 +43,7 @@ namespace xpas
         _phylo_kmer_db(const _phylo_kmer_db&) noexcept = delete;
         _phylo_kmer_db(_phylo_kmer_db&&) noexcept = default;
         _phylo_kmer_db& operator=(const _phylo_kmer_db&) = delete;
-        _phylo_kmer_db& operator=(_phylo_kmer_db&&) noexcept = default;
+        _phylo_kmer_db& operator=(_phylo_kmer_db&&) = default;
         ~_phylo_kmer_db() noexcept = default;
 
         /// \brief Returns the sequence type: DNA or Protein


### PR DESCRIPTION
`_phylo_kmer_db`  object do not allow operator '=' (delete), but allows move assignment.

However, its currently definition contains the noexcept qualifier which raise an error at compilation time:
```
xpas/include/xpas/phylo_kmer_db.h:46:25: note: ‘xpas::_phylo_kmer_db<PhyloKmer>& xpas::_phylo_kmer_db<PhyloKmer>::operator=(xpas::_phylo_kmer_db<PhyloKmer>&&) noexcept [with PhyloKmer = xpas::positioned_phylo_kmer]’ 
is implicitly deleted because its exception-specification does not match the implicit exception-specification ‘’
   46 |         _phylo_kmer_db& operator=(_phylo_kmer_db&&) noexcept = default;
      |                         ^~~~~~~~
```
I removed the `noexcept` qualifier which solves the issue until you deal with implicit exception-specification.
